### PR TITLE
asyncproc: check for valid previous signal handler before reinstating it

### DIFF
--- a/orochi/asyncproc.py
+++ b/orochi/asyncproc.py
@@ -81,15 +81,16 @@ def with_timeout(timeout, func, *args, **kwargs):
             raise Timeout("Function call took too long", func, timeout)
     finally:
         signal.alarm(0)
-        signal.signal(signal.SIGALRM, oldhandler)
-        if oldalarm != 0:
-            t1 = time.time()
-            remaining = oldalarm - int(t1 - t0 + 0.5)
-            if remaining <= 0:
-                # The old alarm has expired.
-                os.kill(os.getpid(), signal.SIGALRM)
-            else:
-                signal.alarm(remaining)
+        if oldhandler is not None:
+            signal.signal(signal.SIGALRM, oldhandler)
+            if oldalarm != 0:
+                t1 = time.time()
+                remaining = oldalarm - int(t1 - t0 + 0.5)
+                if remaining <= 0:
+                    # The old alarm has expired.
+                    os.kill(os.getpid(), signal.SIGALRM)
+                else:
+                    signal.alarm(remaining)
 
     return retval
 


### PR DESCRIPTION
If the previous signal handler was not installed from Python, a value of
`None` is returned by `signal.signal`. This occurs when Python calls the
destructors during system exit.

Fixes #27
