### PR TITLE
liked_mixes crashed orochi on second run

### DIFF
--- a/orochi/client.py
+++ b/orochi/client.py
@@ -53,7 +53,11 @@ class ConfigFile(object):
     each write."""
 
     DEFAULT_CONFIG_KEYS = ['mplayer_extra_arguments', 'username', 'password',
-             'autologin', 'results_per_page', 'results_sorting']
+                           'autologin', 'results_per_page', 'results_sorting']
+    DEFAULTS = {
+        'results_per_page': 10,
+        'results_sorting': 'hot',
+    }
 
     def __init__(self, filename=None):
         if not filename:
@@ -143,13 +147,17 @@ class Client(CmdExitMixin, cmd.Cmd, object):
         self.total_pages = None
         self.query_type = None
 
-        if not self.config['results_per_page']:
-            self.config['results_per_page'] = self._results_per_page = 10
-        elif not self.config['results_sorting']:
-            self.config['results_sorting'] = self._results_sorting = 'hot'
-        else:
+        # Set some config defaults
+        if self.config['results_per_page']:
             self._results_per_page = self.config['results_per_page']
+        else:
+            default_value = ConfigFile.DEFAULTS.get('results_per_page')
+            self.config['results_per_page'] = self._results_per_page = default_value
+        if self.config['results_sorting']:
             self._results_sorting = self.config['results_sorting']
+        else:
+            default_value = ConfigFile.DEFAULTS.get('results_sorting')
+            self.config['results_sorting'] = self._results_sorting = default_value
 
         # Try to login if autologin is on.
         if self.config['username'] and self.config['password'] and self.config['autologin']:


### PR DESCRIPTION
traceback as follows:
```
(8tracks)> liked_mixes
Traceback (most recent call last):
  File "/home/daniel/venv/bin/orochi", line 11, in <module>
    sys.exit(main())
  File "/home/daniel/venv/local/lib/python2.7/site-packages/orochi/client.py", line 732, in main
    client.cmdloop()
  File "/home/daniel/venv/local/lib/python2.7/site-packages/orochi/client.py", line 169, in cmdloop
    super(Client, self).cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/home/daniel/venv/local/lib/python2.7/site-packages/orochi/client.py", line 406, in do_liked_mixes
    self.do_search_user_liked(self._user_name)
  File "/home/daniel/venv/local/lib/python2.7/site-packages/orochi/client.py", line 250, in do_search_user_liked
    mixes = self.search_request(s, 'user_liked')
  File "/home/daniel/venv/local/lib/python2.7/site-packages/orochi/client.py", line 423, in search_request
    self.config['results_sorting'], self._search_results_page, self._results_per_page)
AttributeError: 'Client' object has no attribute '_results_per_page'
```

I've never really done any programming in python but I assume it's down to _results_per_page not being instantiated properly on first run, or something I've messed up on in setting up my venv.

Started orochi up again, ran liked_mixes with no issue, I'll try reproduce (clear out my config and run again).

Thanks for the program, helpful help command, simple to use + saves me a bunch of cpu over the web interface :)