### PR TITLE
Add terminal title option; enable readline history

### DIFF
--- a/orochi/client.py
+++ b/orochi/client.py
@@ -59,7 +59,7 @@ class ConfigFile(object):
     DEFAULTS = {
         'results_per_page': 10,
         'results_sorting': 'hot',
-        'terminal_title': 'no',
+        'terminal_title': 'yes',
     }
 
     def __init__(self, filename=None):

--- a/orochi/colors.py
+++ b/orochi/colors.py
@@ -19,6 +19,6 @@ ANSI_WINDOW_NAME_END = '\007'
 def bold(text):
     return ''.join([ANSI_BOLD, text, ANSI_NORMAL])
 
+
 def title(text):
     return ''.join([ANSI_WINDOW_NAME_START, text, ANSI_WINDOW_NAME_END])
-

--- a/orochi/colors.py
+++ b/orochi/colors.py
@@ -10,9 +10,15 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 ANSI_BOLD = '\033[1m'
 ANSI_NORMAL = '\033[22m'
+ANSI_WINDOW_NAME_START = '\033]2;'
+ANSI_WINDOW_NAME_END = '\007'
 
 
 # Helper functions
 
 def bold(text):
     return ''.join([ANSI_BOLD, text, ANSI_NORMAL])
+
+def title(text):
+    return ''.join([ANSI_WINDOW_NAME_START, text, ANSI_WINDOW_NAME_END])
+

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -8,3 +8,9 @@ def test_bold():
     """Test whether the bold() function works properly."""
     assert colors.bold('spam') == colors.ANSI_BOLD + 'spam' + colors.ANSI_NORMAL
     assert colors.bold('spam') == '\033[1mspam\033[22m'
+
+def test_title():
+    """Test whether title() generates the correct strings."""
+    assert colors.title('spam') == colors.ANSI_WINDOW_NAME_START + 'spam' + \
+                                   colors.ANSI_WINDOW_NAME_END
+    assert colors.title('spam') == '\033]2;spam\007'

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -9,6 +9,7 @@ def test_bold():
     assert colors.bold('spam') == colors.ANSI_BOLD + 'spam' + colors.ANSI_NORMAL
     assert colors.bold('spam') == '\033[1mspam\033[22m'
 
+
 def test_title():
     """Test whether title() generates the correct strings."""
     assert colors.title('spam') == colors.ANSI_WINDOW_NAME_START + 'spam' + \


### PR DESCRIPTION
* Use ANSI control codes to output current song/artist to terminal title. Off by default, stores in settings like all other settings. Updates each time status is updated.
* Enable readline history for persistently scrolling through history. History file stored in same dir as config, silently fails if it can't load/save it, since it's a nonessential feature.

Cheers,
Brendan