### PR TITLE
Port to Python3

### DIFF
--- a/orochi/client.py
+++ b/orochi/client.py
@@ -18,6 +18,7 @@ from .player import MPlayer
 from .errors import InitializationError, TerminatedError
 from .colors import bold
 
+PY3 = sys.version_info > (3,)
 
 # Tuple containing prefix, main text and suffix for command line prompt
 DEFAULT_PROMPT = ('(', '8tracks', ')> ')
@@ -75,7 +76,7 @@ class ConfigFile(object):
             self.config = {}
         else:
             with open(self.filename, 'r') as configfile:
-                conf = ' '.join(configfile.xreadlines())
+                conf = ' '.join(configfile.readlines())
                 if conf == '':
                     self.config = {}
                 else:
@@ -368,7 +369,11 @@ class Client(CmdExitMixin, cmd.Cmd, object):
                 return
             except HTTPError as e:
                 print('*** HTTP Error: {}'.format(e))
-            i.prompt = get_prompt(mix).encode('utf8')
+
+            i.prompt = get_prompt(mix)
+            if not PY3:
+                i.prompt = i.prompt.encode('utf8')
+
             i.cmdloop()
 
     def help_play(self):
@@ -583,7 +588,10 @@ class PlayCommand(cmd.Cmd, object):
         print('Skipping to the next mix...')
         mix = self.api.next_mix(self.mix_id)
         self.mix_id = mix['id']
-        self.prompt = get_prompt(mix).encode('utf8')
+        self.prompt = get_prompt(mix)
+
+        if not PY3:
+            self.prompt = self.prompt.encode('utf8')
 
         self.status = self.api.play_mix(self.mix_id)
         self.p.load(self.status['track']['url'])

--- a/orochi/player.py
+++ b/orochi/player.py
@@ -216,6 +216,12 @@ class MPlayer(object):
         """Shut down mplayer and replace the reference to the async process
         with a dummy instance that raises a :class:`RuntimeError` on any method
         call."""
+
+        if isinstance(self.p, DeadMPlayer):
+            # self.terminate may be call explicitely *and* implicitely,
+            # through self.__del__.
+            return
+
         if hasattr(self, 'p') and hasattr(self.p, 'terminate'):
             self._stop_background_thread()
             self.p.terminate()

--- a/tests/test_asyncproc.py
+++ b/tests/test_asyncproc.py
@@ -27,4 +27,4 @@ sys.exit()
     output = subprocess.check_output([sys.executable, "-Ec", code],
                                      stderr=subprocess.STDOUT)
 
-    assert 'Exception TypeError' not in output
+    assert 'Exception TypeError' not in output.decode("ascii")


### PR DESCRIPTION
Hello,

I've ported orochi code to Python3. It passes the testsuite (after a minor fix on the testsuite itself).

I'm now using it at home, I'll report and fix the bugs I may encounter with this new version.

Regards,

Kevin

---

Tested with Python 3.5.0.

The port mainly consists in handling correctly byte-string and
unicode strings. File buffering is also handled a bit differently,
and a race condition on player termination appeared in my PY3
environment but on in PY2.