### PR TITLE
Fix bug if track doesn't have a performer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ UNRELEASED
 
 - [add] Persist readline history
 - [add] Set terminal title to song status
+- [bug] Fixed bug that occurs if a track doesn't have an artist specified (#68)
 
 v0.1.3 (2016-01-06)
 

--- a/orochi/client.py
+++ b/orochi/client.py
@@ -671,7 +671,7 @@ class PlayCommand(cmd.Cmd, object):
         # Get and clean track info
         track = self.status['track']
         track_name = track['name'].strip()
-        track_performer = track['performer'].strip()
+        track_performer = track.get('performer', 'Unknown Artist').strip()
         track_album = track.get('release_name', '').strip()
         track_year = track.get('year')
 


### PR DESCRIPTION
Some tracks don't contain a performer:

(sorry for the cut-off stack trace)

```
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/danilo/Projects/orochi/orochi/client.py", lin
    main()
  File "/home/danilo/Projects/orochi/orochi/client.py", lin
    client.cmdloop()
  File "/home/danilo/Projects/orochi/orochi/client.py", lin
    super(Client, self).cmdloop()
  File "/usr/lib/python3.5/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.5/cmd.py", line 217, in onecmd
    return func(arg)
  File "/home/danilo/Projects/orochi/orochi/client.py", lin
    i.cmdloop()
  File "/home/danilo/Projects/orochi/orochi/client.py", lin
    super(PlayCommand, self).cmdloop()
  File "/usr/lib/python3.5/cmd.py", line 126, in cmdloop
    line = input(self.prompt)
  File "/home/danilo/Projects/orochi/orochi/client.py", lin
    self.do_status()
  File "/home/danilo/Projects/orochi/orochi/client.py", lin
    track_performer = track['performer'].strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

This should fix it, by falling back to "Unknown Artist".