### PR TITLE
search_tags fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ UNRELEASED
 - [add] Persist readline history
 - [add] Set terminal title to song status
 - [bug] Fixed bug that occurs if a track doesn't have an artist specified (#68)
+- [bug] Fixed ``search_tags`` command on Python 3 (#70)
 - [add] Support ``-v`` / ``--version`` argument
 
 v0.1.3 (2016-01-06)

--- a/orochi/api.py
+++ b/orochi/api.py
@@ -160,7 +160,7 @@ class EightTracksAPI(object):
 
         if query_type == 'tag':
             parts = query.split(',')
-            tags = filter(None, map(lambda p: p.strip(), parts))
+            tags = [p.strip() for p in parts if p]
             if len(tags) < 1:
                 params['tag'] = query
             else:


### PR DESCRIPTION
I started using orochi today but I noticed (using py3.5) that the `search_tags` command seems not to work as advertised:

```
(8tracks)> search_tags night, sleep
Traceback (most recent call last):
  File ".../venv/bin/orochi", line 11, in <module>
    sys.exit(main())
  File ".../venv/lib/python3.5/site-packages/orochi/client.py", line 748, in main
    client.cmdloop()
  File ".../venv/lib/python3.5/site-packages/orochi/client.py", line 178, in cmdloop
    super(Client, self).cmdloop()
  File "/usr/lib/python3.5/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.5/cmd.py", line 217, in onecmd
    return func(arg)
  File ".../venv/lib/python3.5/site-packages/orochi/client.py", line 230, in do_search_tags
    mixes = self.search_request(s, 'tag')
  File ".../venv/lib/python3.5/site-packages/orochi/client.py", line 436, in search_request
    self.config['results_sorting'], self._search_results_page, self._results_per_page)
  File ".../venv/lib/python3.5/site-packages/orochi/api.py", line 162, in search_mix
    if len(tags) < 1:
TypeError: object of type 'filter' has no len()
```

I recon the issue comes from around here: https://github.com/dbrgn/orochi/blob/master/orochi/api.py#L164